### PR TITLE
Update to zig 0.12.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.11.0
+          version: 0.12.0
       - name: install libudev
         run: sudo apt install -y libudev-dev
       - name: build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.11.0
+          version: 0.12.0
       - name: build
         run: zig build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.11.0
+          version: 0.12.0
       - name: build
         run: zig build

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,4 +1,11 @@
 .{
     .name = "libusb",
     .version = "1.0.26",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "COPYING",
+        "README.md",
+        "libusb",
+    },
 }


### PR DESCRIPTION
This is an alternate (compared to #2) PR.

The changes are:

  - I set the `zig` version to `0.12.0` instead of master.
    Additionally I also update the `macos.yml` and `windows.yml` workflows.

  - In `zig.build.zon`, in `path` I added the `COPYING` and `README.md` files (the latter is symlink) and the `libusb` directory.
    Not sure if this is the correct way.
 
  - When configuring C source files, I removed `.ios`, `.watchos` and `.tvos`.
    The libusb website says that `ios` is not supported.

  - When configuring headers, I used `target.result.isAndroid()`.
