### PR TITLE
add config.h.in to build.zig.zon paths

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,5 +7,6 @@
         "build.zig",
         "build.zig.zon",
         "libusb",
+        "config.h.in",
     },
 }


### PR DESCRIPTION
i cant use `b.dependecy("libusb").artifact("usb")` without it ;-)