### PR TITLE
Added option to not depend on libudev on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ xcuserdata
 *.xcworkspace
 zig-cache
 zig-out
+.zig-cache


### PR DESCRIPTION
my application:
https://github.com/dasimmet/zig-raspberry-pico-sdk

does not need it anyways and can be statically linked without this