### PR TITLE
Link to CoreFoundation framework

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -53,8 +53,9 @@ fn create_libusb(
 
     if (target.result.isDarwin()) {
         lib.addCSourceFiles(.{ .files = darwin_src });
-        lib.linkFrameworkNeeded("IOKit");
-        lib.linkFrameworkNeeded("Security");
+        lib.linkFramework("CoreFoundation");
+        lib.linkFramework("IOKit");
+        lib.linkFramework("Security");
     } else if (target.result.os.tag == .linux) {
         lib.addCSourceFiles(.{ .files = linux_src });
         if (system_libudev) {


### PR DESCRIPTION
This PR changes the deprecated `linkFrameworkNeeded` calls to `linkFramework` and adds a line to link the `CoreFoundation` framework. Otherwise, I received 

`error: undefined symbol: _CFRetain`

and others when trying to compile the library. 