### PR TITLE
Add platform folders which contain the config.h files to build.zig.zon

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,5 +8,8 @@
         "build.zig.zon",
         "libusb",
         "config.h.in",
+        "Xcode",
+        "android",
+        "msvc",
     },
 }


### PR DESCRIPTION
This PR adds the platform dependent folders "Xcode", "android", "msvc" to the build.zig.zon 'paths' variable. 

Otherwise, when using 

`zig fetch --save git+https://github.com/allyourcodebase/libusb#d9bc1457b0d3cc5c39a4dc845d6974f52dac2dea`  (current master commit),

and then linking the libusb library to your own executable via 

```
    const libusb = b.dependency("libusb", .{.target = target, .optimize = optimize});
    exe.linkLibrary(libusb.artifact("usb"));
```

the build fails with:

```
error: 'config.h' file not found
#include <config.h>
```

because the zig package manager only copies the files and folders referenced in the package's `paths` definition in build.zig.zon.
The paths currently do not contain these folders needed for compiling the library on e.g. MacOS.


By adding the mentionend folders, compilation should succeed on all platforms, because the `config.h` can now be found.


The relevant lines in the build.zig file:

https://github.com/allyourcodebase/libusb/blob/d9bc1457b0d3cc5c39a4dc845d6974f52dac2dea/build.zig#L80-L90

